### PR TITLE
removed privacy rootDir

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -19,7 +19,6 @@ export default defineConfig({
         item: resolve(rootDir, "pages/item.html"),
         listings: resolve(rootDir, "pages/listings.html"),
         login: resolve(rootDir, "pages/login.html"),
-        privacy: resolve(rootDir, "pages/privacy.html"),
         profile: resolve(rootDir, "pages/profile.html"),
         register: resolve(rootDir, "pages/register.html"),
         terms: resolve(rootDir, "pages/terms.html"),


### PR DESCRIPTION
This pull request makes a small update to the Vite configuration by removing the `privacy` page from the build input list. This change will prevent the `privacy.html` file from being included in the build outputs.